### PR TITLE
Fix butterknife compilation by patching aar

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -15,6 +15,9 @@ maven_install(
         "com.jakewharton:butterknife:10.2.3",
     ],
     maven_install_json = "//:maven_install.json",
+    override_targets = {
+        "com.jakewharton:butterknife": "@//patches:com_jakewharton_butterknife",
+    },
     repositories = [
         "https://maven.google.com",
         "https://repo1.maven.org/maven2",

--- a/patches/BUILD.bazel
+++ b/patches/BUILD.bazel
@@ -1,0 +1,14 @@
+load(":patches.bzl", "aar_fix_manifest")
+
+aar_import(
+    name = "com_jakewharton_butterknife",
+    aar = aar_fix_manifest(
+        name = "_com_jakewharton_butterknife",
+        aar = "@maven//:v1/https/repo1.maven.org/maven2/com/jakewharton/butterknife/10.2.3/butterknife-10.2.3.aar",
+    ),
+    tags = ["maven_coordinates=com.jakewharton:butterknife:10.2.3"],
+    visibility = [
+        "//visibility:public",
+    ],
+    deps = ["@maven//:com_jakewharton_butterknife_runtime"],
+)

--- a/patches/patches.bzl
+++ b/patches/patches.bzl
@@ -1,0 +1,25 @@
+def aar_fix_manifest(name, aar):
+    """
+    Patches AndroidManifest.xml package to contain `.` as expected by aapt2 in bazel.
+    """
+    aar_out = "patched_" + name + ".aar"
+    native.genrule(
+        name = name,
+        srcs = [aar],
+        outs = [aar_out],
+        tools = ["@bazel_tools//tools/zip:zipper"],
+        cmd = """
+         TEMP="aar"
+         mkdir -p $$TEMP
+         unzip -q -o $< -d $$TEMP/
+         sed -i.bak -e 's/package=\\"butterknife\\"/package=\\"com.butterknife\\"/g' $$TEMP/AndroidManifest.xml
+         rm $$TEMP/AndroidManifest.xml.bak
+         out=$$(pwd)/out.aar
+         zipper=$$(pwd)/$(location {zipper})
+         cd $$TEMP; find * -type f -exec $$zipper c $$out {{}} +
+         cd ..
+         cp $$out $(OUTS)
+         rm -rf $$TEMP
+         """.format(zipper = "@bazel_tools//tools/zip:zipper"),
+    )
+    return aar_out


### PR DESCRIPTION
Adds a `genrule` to patch butterknife's AndroidManifest.xml to contain `.` as expected by Bazel.

`rules_jvm_external`'s `override_targets` makes it easier to replace usages everywhere.